### PR TITLE
feat: add attack and spellcasting section

### DIFF
--- a/client/src/lib/components/character-sheet/AttacksRow.svelte
+++ b/client/src/lib/components/character-sheet/AttacksRow.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  interface Props {
+    name?: string;
+    atkBonus?: string;
+    dmgType?: string;
+  }
+
+  let { name, atkBonus, dmgType }: Props = $props();
+
+  let localName = $state(name || '');
+  let localAtkBonus = $state(atkBonus || '');
+  let localDmgType = $state(dmgType || '');
+</script>
+
+<tr>
+  <td>
+    {#if name}
+      <p
+        class="bg-gray-700 m-1 text-center text-xs h-6 rounded-ss-md rounded-ee-md w-24"
+      >
+        {name}
+      </p>
+    {:else}
+      <input
+        class="bg-gray-700 m-1 text-center text-xs h-6 rounded-ss-md rounded-ee-md w-24"
+        aria-label="Attack name"
+        bind:value={localName}
+      />
+    {/if}
+  </td>
+  <td>
+    {#if atkBonus}
+      <p
+        class="bg-gray-700 m-1 text-center text-xs h-6 rounded-ss-md rounded-ee-md w-12"
+      >
+        {localAtkBonus}
+      </p>
+    {:else}
+      <input
+        class="bg-gray-700 m-1 text-center text-xs h-6 rounded-ss-md rounded-ee-md w-12"
+        aria-label="Attack Bonus"
+        bind:value={atkBonus}
+      />
+    {/if}
+  </td>
+  <td>
+    {#if dmgType}
+      <p
+        class="bg-gray-700 m-1 text-center text-xs h-6 rounded-ss-md rounded-ee-md w-31"
+      >
+        {dmgType}
+      </p>
+    {:else}
+      <input
+        class="bg-gray-700 m-1 text-center text-xs h-6 rounded-ss-md rounded-ee-md w-31"
+        aria-label="Damage Type"
+        bind:value={localDmgType}
+      />
+    {/if}
+  </td>
+</tr>

--- a/client/src/routes/character-creator/+page.svelte
+++ b/client/src/routes/character-creator/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import AbilityScore from '$lib/components/character-sheet/AbilityScore.svelte';
+  import AttacksRow from '$lib/components/character-sheet/AttacksRow.svelte';
   import MainInput from '$lib/components/character-sheet/MainInput.svelte';
   import Skills from '$lib/components/character-sheet/Skills.svelte';
   import {
@@ -80,6 +81,19 @@
     flaws:
       'I have a hard time resisting the allure of wealth, especially gold. Wealth can help me restore my legacy.',
   });
+
+  const equipment = [
+    {
+      name: 'greataxe',
+      atkBonus: '+5',
+      dmgType: '1d12 + 3 slashing',
+    },
+    {
+      name: 'javelin',
+      atkBonus: '+5',
+      dmgType: '1d6 + 3 piercing',
+    },
+  ];
 </script>
 
 <div class="flex justify-center character-form">
@@ -191,6 +205,7 @@
             <input
               class="border-0 text-center text-3xl w-full"
               type="number"
+              min="0"
               bind:value={temporaryHitPoints}
             />
           </div>
@@ -266,7 +281,33 @@
           </div>
         {/each}
       </div>
-      <div class="border rounded h-70"></div>
+      <div class="border rounded h-115 flex flex-col justify-between p-2">
+        <table class="table-auto">
+          <thead>
+            <tr>
+              <th class="uppercase text-[0.6rem] font-normal text-gray-400"
+                >name</th
+              >
+              <th class="uppercase text-[0.6rem] font-normal text-gray-400"
+                >atk bonus</th
+              >
+              <th class="uppercase text-[0.6rem] font-normal text-gray-400"
+                >damage/type</th
+              >
+            </tr>
+          </thead>
+          <tbody>
+            {#each equipment as { name, atkBonus, dmgType }}
+              <AttacksRow {name} {atkBonus} {dmgType} />
+            {/each}
+            <AttacksRow />
+            <AttacksRow />
+          </tbody>
+        </table>
+        <p class="uppercase text-center text-xs font-bold">
+          Attacks & spellcasting
+        </p>
+      </div>
       <div class="border rounded row-span-2"></div>
       <div class="border rounded h-70"></div>
       <div class="border rounded h-70"></div>


### PR DESCRIPTION
add attack and spellcasting section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an equipment table displaying weapon name, attack bonus, and damage/type in the character creator.
  * Introduced editable rows for adding or modifying attack details.
* **Improvements**
  * The temporary hit points input now enforces a minimum value of zero for better data accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->